### PR TITLE
source ~/.bashrc

### DIFF
--- a/src/functions/installNilup.ts
+++ b/src/functions/installNilup.ts
@@ -22,8 +22,8 @@ export async function installNilup() {
     if (execError.stderr && execError.stderr.includes("You may begin using nilup now!")) {
       console.log("Nilup installed or updated successfully!");
       console.log("Please source your shell configuration to update your environment:");
-		  console.log("For Bash users: source ~/.bashrc");
-		  console.log("Or, you can simply restart your terminal session to apply changes.");
+      console.log("For Bash users: source ~/.bashrc");
+      console.log("Or, you can simply restart your terminal session to apply changes.");
     } else {
       console.error("Failed to install Nilup. Error details:", execError.message);
       if (execError.stdout) console.error("stdout:", execError.stdout);


### PR DESCRIPTION
## Reason for PR

After running `npx @nillion/create-nillion-app` I encountered the error `/bin/sh: 1: nada: not found`, I didn't know I had to call `source ~/.bashrc` and run the command again.

### Error

```sh
                      @@@@     @@@@@@    @@@@@@     @@@@
                     @@@@@@@   @@@@@@    @@@@@@    @@@@@@@
                     @@@@@@    @@@@@@    @@@@@@    @@@@@@@
                       @@      @@@@@@    @@@@@@      @@
                               @@@@@@    @@@@@@
@@@@@@@@@@@@@@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@          @@@@@@@         @@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@      @@@@@@@@@@@@@@      @@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@     @@@@@@@@@@@@@@@@     @@@@@@@@@@@@@@@@@
@@@@@@      @@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@    @@@@@@      @@@@@@    @@@@@@     @@@@@@
@@@@@@      @@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@   @@@@@@        @@@@@@   @@@@@@     @@@@@@
@@@@@@      @@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@   @@@@@@        @@@@@@   @@@@@@     @@@@@@
@@@@@@      @@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@    @@@@@@       @@@@@    @@@@@@     @@@@@@
@@@@@@      @@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@     @@@@@@@@@@@@@@@@@    @@@@@@     @@@@@@
@@@@@@      @@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@      @@@@@@@@@@@@@@      @@@@@@     @@@@@@
@@@@@@      @@@@@     @@@@@    @@@@@@    @@@@@@     @@@@@         @@@@@@@@         @@@@@@     @@@@@@

Welcome to create-nillion-app - the quickstart Nillion CLI
What would you like to name your project? (default: nillion-quickstart): asda
--------------------
Creating project: asda
--------------------
Checking if Nilup is installed...
--------------------
Installing nilup... This may take a few minutes.🙏 
--------------------
Creating Next.js project... 
This should take ~ 1 minute. Feel free to go stretch you legs / grab a coffee ☕️
Setting up Nada project...
/bin/sh: 1: nada: not found
An error occurred during the setup process: Error: Command failed: nada init nada
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:889:11)
    at execSync (node:child_process:961:15)
    at setupNadaFolder (file:///home/john/.npm/_npx/2cab22b72da09505/node_modules/@nillion/create-nillion-app/dist/src/functions/setupNadaFolder.js:4:5)
    at createNextJsProject (file:///home/john/.npm/_npx/2cab22b72da09505/node_modules/@nillion/create-nillion-app/dist/src/functions/createNextJsProject.js:57:5)
    at main (file:///home/john/.npm/_npx/2cab22b72da09505/node_modules/@nillion/create-nillion-app/dist/src/index.js:22:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  status: 127,
  signal: null,
  output: [ null, null, null ],
  pid: 28543,
  stdout: null,
  stderr: null
}
```